### PR TITLE
Add customization option for color preview of FormBuilderColorPickerField

### DIFF
--- a/lib/src/fields/form_builder_color_picker.dart
+++ b/lib/src/fields/form_builder_color_picker.dart
@@ -177,7 +177,8 @@ class FormBuilderColorPickerField extends FormBuilderField<Color> {
         );
 
   @override
-  FormBuilderColorPickerFieldState createState() => FormBuilderColorPickerFieldState();
+  FormBuilderColorPickerFieldState createState() =>
+      FormBuilderColorPickerFieldState();
 }
 
 class FormBuilderColorPickerFieldState

--- a/lib/src/fields/form_builder_color_picker.dart
+++ b/lib/src/fields/form_builder_color_picker.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/lib/src/fields/form_builder_color_picker.dart
+++ b/lib/src/fields/form_builder_color_picker.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -66,6 +67,8 @@ class FormBuilderColorPickerField extends FormBuilderField<Color> {
   final bool enableInteractiveSelection;
   final InputCounterWidgetBuilder? buildCounter;
 
+  final Widget Function(Color?)? colorPreviewBuilder;
+
   FormBuilderColorPickerField({
     Key? key,
     //From Super
@@ -109,6 +112,7 @@ class FormBuilderColorPickerField extends FormBuilderField<Color> {
     this.enableInteractiveSelection = true,
     this.buildCounter,
     this.controller,
+    this.colorPreviewBuilder,
   }) : super(
           key: key,
           initialValue: initialValue,
@@ -127,23 +131,19 @@ class FormBuilderColorPickerField extends FormBuilderField<Color> {
             return TextField(
               style: style,
               decoration: state.decoration.copyWith(
-                suffixIcon: LayoutBuilder(
-                  key: ObjectKey(state.value),
-                  builder: (context, constraints) {
-                    return Container(
-                      key: ObjectKey(state.value),
-                      height: constraints.minHeight,
-                      width: constraints.minHeight,
-                      decoration: BoxDecoration(
-                        color: state.value,
-                        shape: BoxShape.circle,
-                        border: Border.all(
-                          color: Colors.black,
-                        ),
+                suffixIcon: colorPreviewBuilder != null
+                    ? colorPreviewBuilder(field.value)
+                    : LayoutBuilder(
+                        key: ObjectKey(state.value),
+                        builder: (context, constraints) {
+                          return Icon(
+                            Icons.circle,
+                            key: ObjectKey(state.value),
+                            size: constraints.minHeight,
+                            color: state.value,
+                          );
+                        },
                       ),
-                    );
-                  },
-                ),
               ),
               enabled: state.enabled,
               readOnly: readOnly,
@@ -178,8 +178,7 @@ class FormBuilderColorPickerField extends FormBuilderField<Color> {
         );
 
   @override
-  FormBuilderColorPickerFieldState createState() =>
-      FormBuilderColorPickerFieldState();
+  FormBuilderColorPickerFieldState createState() => FormBuilderColorPickerFieldState();
 }
 
 class FormBuilderColorPickerFieldState


### PR DESCRIPTION
Close: #19 

## Problem
Color preview of FormBuilderColorPickerField was not correctly laid out (missing padding) in form fields with OutlineInputBorder. Also, currently there is no option to provide a custom color preview.
## Solution description
This PR swaps the current color preview (a colored Container) with a colored circular icon, which is correctly formatted (as suffixIcon expects an icon). 

## Screenshots or Videos

Without changes:
<img src="https://user-images.githubusercontent.com/79228196/196187139-d0047278-d9fb-4c52-b016-bc3a2e930d81.jpg" width="150">

With changes (top: default, bottom: custom preview provided with code below):
<img src="https://user-images.githubusercontent.com/79228196/196187261-b460cb24-5d31-475c-9dc9-fa389273b713.jpg" width="150">
<img src="https://user-images.githubusercontent.com/79228196/196187279-1a452d49-b18a-4405-820d-456d79394220.jpg" width="150">
``` 
FormBuilderColorPickerField(
...,
colorPreviewBuilder: (color) => Padding(
                    padding: EdgeInsets.all(8),
                    child: Container(
                      color: color,
                      height: 24,
                      width: 24,
                    ),
                  ),
)
```