### PR TITLE
Fixed bad pad field performance on web.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [8.4.0] - 26-Oct-2022
+## [8.4.0] - 28-Oct-2022
 
 * Set by default flex loose to `FormBuilderSearchableDropdown`
 * Set show search field by default
@@ -6,6 +6,7 @@
 * Bumped dependencies :
   * `flutter_form_builder` from 7.3.1 to 7.7.0
   * `dropdown_search` from 5.0.2 to 5.0.3
+* Performance improvement on FormBuilderSignaturePad on Web
 
 ## [8.3.0] - 27-Jul-2022
 


### PR DESCRIPTION
## Solution description

Now the field values are only updated when you finish typing and not every time the pad changes is listened. Better performance on Flutter Web

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme
