### PR TITLE
#26 fixed

### DIFF
--- a/lib/src/widgets/flutter_chips_input/chips_input.dart
+++ b/lib/src/widgets/flutter_chips_input/chips_input.dart
@@ -288,7 +288,7 @@ class ChipsInputState<T> extends State<ChipsInput<T>>
     Future.delayed(const Duration(milliseconds: 300), () {
       WidgetsBinding.instance.addPostFrameCallback((_) async {
         final renderBox = context.findRenderObject() as RenderBox;
-        await Scrollable.of(context)?.position.ensureVisible(renderBox);
+        await Scrollable.of(context).position.ensureVisible(renderBox);
       });
     });
   }
@@ -490,4 +490,11 @@ class ChipsInputState<T> extends State<ChipsInput<T>>
 
   @override
   void removeTextPlaceholder() {}
+
+  @override
+  void didChangeInputControl(
+      TextInputControl? oldControl, TextInputControl? newControl) {}
+
+  @override
+  void performSelector(String selectorName) {}
 }

--- a/lib/src/widgets/flutter_chips_input/suggestions_box_controller.dart
+++ b/lib/src/widgets/flutter_chips_input/suggestions_box_controller.dart
@@ -14,7 +14,7 @@ class SuggestionsBoxController {
   void open() {
     if (_isOpened) return;
     assert(overlayEntry != null);
-    Overlay.of(context)?.insert(overlayEntry!);
+    Overlay.of(context).insert(overlayEntry!);
     _isOpened = true;
   }
 


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #26 

## Solution description
In Flutter 3.7 version any class implements the `TextInputClient` need to be override the `didChangeInputControl` and `performSelector` functions.
