### PR TITLE
Deleted controller declaration in TypeAheadField

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -103,7 +103,6 @@ class MyHomePageState extends State<MyHomePage> {
                   itemBuilder: (context, country) {
                     return ListTile(title: Text(country));
                   },
-                  controller: TextEditingController(text: ''),
                   initialValue: 'Uganda',
                   suggestionsCallback: (query) {
                     if (query.isNotEmpty) {


### PR DESCRIPTION
Deleted the controller declaration in the type ahead field example, this way the field has the initial value shown.

## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #91 


## Solution description

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

- [X] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [X] Check the original issue to confirm it is fully satisfied
- [X] Add solution description to help guide reviewers
- [NA] Add unit test to verify new or fixed behaviour
- [NA] If apply, add documentation to code properties and package readme
